### PR TITLE
OTWO-3498: Add example and instructions for OAuth2

### DIFF
--- a/examples/oauth2/README.md
+++ b/examples/oauth2/README.md
@@ -1,0 +1,17 @@
+## Using OAuth 2.0 with the OpenHub API
+
+### What is OAuth 2.0?
+
+[OAuth 2.0](http://oauth.net/2) is the next evolution of the OAuth protocol. It is an open protocol that allows applications and websites to share sensitive data, without requiring you to release your password. Using OAuth, you can permit third-party applications to read from your OpenHub account without having to share your password.
+
+Instead of handing out your OpenHub account password to a third-party application, you visit the OpenHub website directly and grant that application permission to access your OpenHub account. You can revoke this permission any time you change your mind.
+
+### Using OAuth 2.0
+
+In order to become OpenHub OAuth consumer, you'd need to get your key and secret from your [API Keys](https://www.openhub.net/accounts/me/api_keys) page.
+
+The application [ohloh_oauth2_sinatra.rb](/examples/oauth2/ohloh_oauth2_sinatra.rb) is a simple [Sinatra](http://www.sinatrarb.com/) based example using the [oauth2 gem](https://github.com/intridea/oauth2) that fetches authenticated user's [account](/reference/account.md) xml.
+
+### Developer Information
+
+OAuth 2.0 is an optional, additional feature of the OpenHub API that can be used to integrate OpenHub users on your website using their authenticated identity. You can read public data from OpenHub at any time using only your application’s OpenHub API Key.

--- a/examples/oauth2/ohloh_oauth2_sinatra.rb
+++ b/examples/oauth2/ohloh_oauth2_sinatra.rb
@@ -1,0 +1,29 @@
+require 'oauth2'
+require 'sinatra'
+
+enable :sessions
+CALLBACK_URL = 'http://localhost:9292/callback'
+
+# Assumes that you have set OHLOH_KEY and OHLOH_SECRET environment
+# variables to values from your API keys page.
+before do
+  @client = OAuth2::Client.new(ENV['OHLOH_KEY'], ENV['OHLOH_SECRET'],
+                               site: 'https://www.openhub.net',
+                               token_method: :post)
+end
+
+def access_token
+  OAuth2::AccessToken.new(@client, session[:access_token], refresh_token: session[:refresh_token])
+end
+
+get '/login' do
+  redirect @client.auth_code.authorize_url(redirect_uri: CALLBACK_URL)
+end
+
+get '/callback' do
+  new_token = @client.auth_code.get_token(params[:code], redirect_uri: CALLBACK_URL)
+  session[:access_token] = new_token.token
+  session[:refresh_token] = new_token.refresh_token
+
+  access_token.get('accounts/me.xml').body
+end


### PR DESCRIPTION
View the new OAuth2 README using the following url:

https://github.com/blackducksw/ohloh_api/tree/3fd578cbec0f78ed9a583f6619e082e072a04f45/examples/oauth2
